### PR TITLE
Update registries.json

### DIFF
--- a/lib/registries.json
+++ b/lib/registries.json
@@ -4,8 +4,8 @@
       "registry": "https://registry.npmjs.org/"
   },
   "taobao": {
-      "home": "https://npm.taobao.org",
-      "registry": "https://registry.npm.taobao.org/"
+      "home": "https://npmmirror.com",
+      "registry": "https://registry.npmmirror.com/"
   },
   "yarn": {
     "home": "https://yarnpkg.com",


### PR DESCRIPTION
taobao 镜像站域名已更换至 npmmirror.com，老 http://npm.taobao.org 和 http://registry.npm.taobao.org 域名将于 2022 年 05 月 31 日零时起停止服务